### PR TITLE
Fix a typo, change placeholder into sample text

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,8 +26,12 @@
     <form class="color-input-form">
       <label>
         <div>X axis colors (required). Hex, RGB, HSL, HSLA are all supported</div>
-        <small>This can also have variable names (deliniated from the color with a colon (<code>:</code>).</small>
-        <textarea placeholder="hsl(202, 79%, 50%)&#10;#ff0033&#10;rebeccapurple" class="color-input-x" rows="5" required></textarea>
+        <small>This can also have variable names (delimited from the color with a colon (<code>:</code>).</small>
+        <textarea class="color-input-x" rows="5" required>
+          hsl(202, 79%, 50%)
+          #ff0033
+          rebeccapurple
+        </textarea>
       </label>
       <button class="button-reverse" type="button" aria-label="Reverse X and Y axis data">↑↓</button>
       <label>


### PR DESCRIPTION
Placeholders have poor accessibility, and in a tool like this it's nice to have some sample values to start with anyway.